### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
     runs-on: windows-latest


### PR DESCRIPTION
Potential fix for [https://github.com/trackd/FileWatchRest/security/code-scanning/1](https://github.com/trackd/FileWatchRest/security/code-scanning/1)

Add an explicit workflow-level `permissions` block near the top of `.github/workflows/ci.yml` (after `on:` block, before `jobs:`) with least-privilege defaults. For this workflow, `contents: read` is the recommended minimal baseline and satisfies CodeQL’s requirement for explicit token scoping. Keep the existing `create-release` job-level `permissions: contents: write` unchanged so release creation continues to work. This preserves functionality while documenting and enforcing least privilege for `build-and-test` and any future jobs without their own override.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
